### PR TITLE
权限点配置化 & 新命令 & Bug修复 & Actions更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,18 @@ jobs:
           name: "打包的插件"
           path: |
             KMST_${{ github.event.head_commit.id }}.mcdr
+
+      - name: 发布 Pre-release
+        uses: softprops/action-gh-release@v2
+        if: github.ref == 'refs/heads/main'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+          files: KMST_${{ github.event.head_commit.id }}.mcdr
+          prerelease: true
+
+          target_commitish: ${{ github.event.head_commit.id }}
+
+          name: "提交 #${{ github.event.head_commit.id }} by ${{ github.event.head_commit.author }}"
+          body: "主分支提交: #${{ github.event.head_commit.id }}，作者：${{ github.event.head_commit.author }}\n提交信息：\n${{github.event.head_commit.message}}"
+          append_body: "注意：这是一个未确认发布的Pre-release。使用Latest最佳。"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: 处理Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: 安装 MCDReforged
+        run: pip install mcdreforged
+
+      - name: 打包插件
+        run: mcdreforged pack -n KMST_${{ github.event.head_commit.id }}.mcdr
+
+      - name: 提交文件
+        uses: actions/upload-artifact@v4
+        with:
+          name: "打包的插件"
+          path: |
+            KMST_${{ github.event.head_commit.id }}.mcdr

--- a/kmts/__init__.py
+++ b/kmts/__init__.py
@@ -5,6 +5,7 @@ from .constants import VERSION
 from .utils.misc.context import Context
 from .utils.command import initCommandSystem
 from .shared import gctx
+from .utils.permissionUtils import updateAllPermissions
 
 from .utils.configUtils import readFile, writeFile
 from mcdreforged.api.decorator.new_thread import new_thread
@@ -20,6 +21,10 @@ def on_load(server: PluginServerInterface, _):
     readFile()
     server.logger.info(
         f"Success load permission file with {len(gctx.playerLevelsConfigFileContent['players'])} players.")
+
+    server.logger.info(f"Found {len(gctx.playerLevelsConfigFileContent['rootPlayers'])} root players.")
+
+    updateAllPermissions()
 
 
 def on_unload(server: PluginServerInterface):

--- a/kmts/__init__.py
+++ b/kmts/__init__.py
@@ -23,6 +23,7 @@ def on_load(server: PluginServerInterface, _):
         f"Success load permission file with {len(gctx.playerLevelsConfigFileContent['players'])} players.")
 
     server.logger.info(f"Found {len(gctx.playerLevelsConfigFileContent['rootPlayers'])} root players.")
+    server.logger.info(f"Root players: {', '.join(gctx.playerLevelsConfigFileContent['rootPlayers'])}")
 
     updateAllPermissions()
 
@@ -46,5 +47,6 @@ def autoSave():  # 自动保存
             writeFile()
             serverLogger.info("自动保存权限文件完成")
             gctx.saveLock.release()
-        else:  # 无法获得锁说明在退出过程
-            break
+        else:
+            serverLogger.info("Save lock was acquire. maybe in save. skip this save.")
+            continue

--- a/kmts/utils/command/__init__.py
+++ b/kmts/utils/command/__init__.py
@@ -141,7 +141,8 @@ def playerUpgradeConfirm(source: CommandSource, context: CommandContext):
             savePlayerInfo(player1)
 
             # 然后给target增加
-            player2.trustPoint = min(player2.trustPoint + alreadyExistRequest.add, 27)
+            player2.trustPoint = min(player2.trustPoint + alreadyExistRequest.add,
+                                     gctx.configFileContent['trustPointConfig']['max'])
             savePlayerInfo(player2)
             gctx.upgrade.release()
         else:

--- a/kmts/utils/command/__init__.py
+++ b/kmts/utils/command/__init__.py
@@ -49,6 +49,10 @@ def upgradePlayer(source: CommandSource, context: CommandContext):
     else:
         playerStorageName = source.player
 
+    if context['point'] <= 0:
+        source.reply(RText(f"不合法的数字!", RColor.red))
+        return
+
     alreadyExistRequest = gctx.playerUpgradeAwaits.get(playerStorageName, None)
 
     if alreadyExistRequest:

--- a/kmts/utils/configUtils/__init__.py
+++ b/kmts/utils/configUtils/__init__.py
@@ -40,7 +40,7 @@ def readPlayerInfo(playerName) -> Player:
     except KeyError:
         rawInfo = {
             'name': playerName,
-            'points': 0,
+            'points': gctx.configFileContent['trustPointConfig']['default'],
         }
 
     isRoot = False

--- a/kmts/utils/configUtils/__init__.py
+++ b/kmts/utils/configUtils/__init__.py
@@ -8,6 +8,30 @@ defaultPermissionFile = {
     'players': {}
 }
 
+defaultConfigFile = {
+    'trustPointConfig': {
+        'max': 50,
+        'default': 0,
+        'rootPlayer': 30,
+        'levels': {
+            '2': {  # 取头取尾
+                'begin': 1,
+                'end': 13,
+            },
+            '3': {
+                'begin': 14,
+                'end': 27,
+            }
+        },
+        'upgrades': {
+            'cost': {
+                'mul': 0.1,
+                'min': 1
+            }
+        }
+    }
+}
+
 
 def readPlayerInfo(playerName) -> Player:
     # 读取基本信息
@@ -32,8 +56,11 @@ def savePlayerInfo(playerInfo: Player) -> None:
 
 def readFile():  # 插件加载时调用
     PSI: PluginServerInterface = ServerInterface.psi()
-    cfg = PSI.load_config_simple("permission.json", defaultPermissionFile)
-    gctx.playerLevelsConfigFileContent = cfg
+    permission = PSI.load_config_simple("permission.json", defaultPermissionFile)
+    gctx.playerLevelsConfigFileContent = permission
+
+    cfg = PSI.load_config_simple("config.json", defaultConfigFile)
+    gctx.configFileContent = cfg
 
 
 def writeFile():  # 插件卸载时调用

--- a/kmts/utils/configUtils/__init__.py
+++ b/kmts/utils/configUtils/__init__.py
@@ -38,7 +38,10 @@ def readPlayerInfo(playerName) -> Player:
     try:
         rawInfo = gctx.playerLevelsConfigFileContent['players'][playerName]
     except KeyError:
-        raise KeyError("不存在的玩家")
+        rawInfo = {
+            'name': playerName,
+            'points': 0,
+        }
 
     isRoot = False
     if rawInfo['name'] in gctx.playerLevelsConfigFileContent['rootPlayers']:

--- a/kmts/utils/misc/context.py
+++ b/kmts/utils/misc/context.py
@@ -6,8 +6,8 @@ class Context:
     def __init__(self):
         self.playerUpgradeAwaits = dict()
         self.playerLevelsConfigFileContent = dict()
+        self.configFileContent = dict()
 
         self.upgradeProcessing = Lock()
         self.saveLock = Lock()
         self.upgrade = Lock()
-  

--- a/kmts/utils/permissionUtils/__init__.py
+++ b/kmts/utils/permissionUtils/__init__.py
@@ -13,10 +13,14 @@ def setPermissionLevelForPlayer(playerName, targetLevel):
 
 def updateAllPermissions():
     server = ServerInterface.get_instance()
-
+    server.logger.info("Updating all permission...")
     for playerName, _ in gctx.playerLevelsConfigFileContent['players'].items():
         if server.get_permission_level(playerName) != getMCDRPermissionLevel(readPlayerInfo(playerName)):
+            server.logger.info(
+                f"Updating: {playerName} from {server.get_permission_level(playerName)} to {getMCDRPermissionLevel(readPlayerInfo(playerName))}")
             if server.get_permission_level(playerName) >= 3:
+                continue
+            elif not getMCDRPermissionLevel(readPlayerInfo(playerName)):
                 continue
             # 更新玩家权限，同时广播告知
             server.tell(playerName, RText(f"你现在是")+RText(getPointName(readPlayerInfo(playerName)),

--- a/kmts/utils/permissionUtils/point.py
+++ b/kmts/utils/permissionUtils/point.py
@@ -6,8 +6,8 @@ from ...shared import gctx
 def getUpgradeCost(player, addPoint: int) -> int:
     if player.isRootPlayer:
         return 0
-    costPoint = max(int(addPoint*gctx.configFileContent['trustPointConfig']['cost']['mul']) +
-                    addPoint, addPoint+gctx.configFileContent['trustPointConfig']['cost']['min'])
+    costPoint = max(int(addPoint*gctx.configFileContent['trustPointConfig']['upgrades']['cost']['mul']) +
+                    addPoint, addPoint+gctx.configFileContent['trustPointConfig']['upgrades']['cost']['min'])
     return costPoint
 
 
@@ -46,7 +46,7 @@ def getPointName(player: Player) -> str:
         match p:
             case p if gctx.configFileContent['trustPointConfig']['levels']['2']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['2']['end']:
                 return "2级玩家"
-            case p if gctx.configFileContent['trustPointConfig']['levels']['3']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['3']['end']:
+            case p if gctx.configFileContent['trustPointConfig']['levels']['3']['begin'] <= p <= gctx.configFileContent['trustPointConfig']['levels']['3']['end']:
                 return "3级玩家"
             case p if p > gctx.configFileContent['trustPointConfig']['max']:
                 return "管理员或根玩家"
@@ -62,7 +62,7 @@ def getMCDRPermissionLevel(player: Player) -> int:
         match p:
             case p if gctx.configFileContent['trustPointConfig']['levels']['2']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['2']['end']:
                 return 1
-            case p if gctx.configFileContent['trustPointConfig']['levels']['3']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['3']['end']:
+            case p if gctx.configFileContent['trustPointConfig']['levels']['3']['begin'] <= p <= gctx.configFileContent['trustPointConfig']['levels']['3']['end']:
                 return 2
             case p if p > gctx.configFileContent['trustPointConfig']['max']:
                 return None

--- a/kmts/utils/permissionUtils/point.py
+++ b/kmts/utils/permissionUtils/point.py
@@ -1,11 +1,13 @@
 #
 from ..configUtils.classes import Player
+from ...shared import gctx
 
 
 def getUpgradeCost(player, addPoint: int) -> int:
     if player.isRootPlayer:
         return 0
-    costPoint = max(int(addPoint / 10) + addPoint, addPoint+1)
+    costPoint = max(int(addPoint*gctx.configFileContent['trustPointConfig']['cost']['mul']) +
+                    addPoint, addPoint+gctx.configFileContent['trustPointConfig']['cost']['min'])
     return costPoint
 
 
@@ -18,28 +20,12 @@ def getUpgradeLevel(player: Player, costPoint: int) -> int:
     else:
         p = UpgradedtrustPoint
         match p:
-            case p if 1 <= p < 13:
+            case p if gctx.configFileContent['trustPointConfig']['levels']['2']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['2']['end']:
                 return "2级玩家"
-            case p if 14 <= p <= 27:
+            case p if gctx.configFileContent['trustPointConfig']['levels']['3']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['3']['end']:
                 return "3级玩家"
-            case p if p > 27:
+            case p if p > gctx.configFileContent['trustPointConfig']['max']:
                 return "管理员或根玩家"
-
-
-def getUpgradeAddInt(player: Player) -> int:
-    if player.isRootPlayer:
-        return 16
-    elif player.trustPoint == 0:
-        return False
-    else:
-        p = player.trustPoint
-        match p:
-            case p if 1 <= p < 13:
-                return 4
-            case p if 14 <= p <= 27:
-                return 7
-            case p if p > 27:
-                return 8
 
 
 def canUpgrade(player: Player, costPoint: int):
@@ -58,11 +44,11 @@ def getPointName(player: Player) -> str:
     else:
         p = player.trustPoint
         match p:
-            case p if 1 <= p < 13:
+            case p if gctx.configFileContent['trustPointConfig']['levels']['2']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['2']['end']:
                 return "2级玩家"
-            case p if 14 <= p <= 27:
+            case p if gctx.configFileContent['trustPointConfig']['levels']['3']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['3']['end']:
                 return "3级玩家"
-            case p if p > 27:
+            case p if p > gctx.configFileContent['trustPointConfig']['max']:
                 return "管理员或根玩家"
 
 
@@ -74,17 +60,17 @@ def getMCDRPermissionLevel(player: Player) -> int:
     else:
         p = player.trustPoint
         match p:
-            case p if 1 <= p < 13:
+            case p if gctx.configFileContent['trustPointConfig']['levels']['2']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['2']['end']:
                 return 1
-            case p if 14 <= p <= 27:
+            case p if gctx.configFileContent['trustPointConfig']['levels']['3']['begin'] <= p < gctx.configFileContent['trustPointConfig']['levels']['3']['end']:
                 return 2
-            case p if p > 27:
+            case p if p > gctx.configFileContent['trustPointConfig']['max']:
                 return None
 
 
 def isUpgradeUseless(player1: Player, addPoint: int) -> bool:
     if player1.isRootPlayer:
         return True
-    elif player1.trustPoint + addPoint > 27:
+    elif player1.trustPoint + addPoint > gctx.configFileContent['trustPointConfig']['max']:
         return True
     return False

--- a/kmts/utils/permissionUtils/point.py
+++ b/kmts/utils/permissionUtils/point.py
@@ -52,7 +52,7 @@ def getPointName(player: Player) -> str:
                 return "管理员或根玩家"
 
 
-def getMCDRPermissionLevel(player: Player) -> int:
+def getMCDRPermissionLevel(player: Player) -> int | None:
     if player.isRootPlayer:
         return None
     elif player.trustPoint == 0:


### PR DESCRIPTION
# 配置化

将所有的权限点配置化，可修改：

- 最大点数
- 默认点数
- 2、3级所需的点数
- 升级手续费乘数

# Bug修复与命令添加

## 44486abd 、7444a3d、5ec5e4d：

- 修复了在根玩家未保存权限点（尤其是刚装上插件）时，命令返回错误结果
- 添加了`!!ts reloadPermissionFile`命令，可在服务器运行时重载权限文件而不重载插件